### PR TITLE
Fixed giving of the death list in dimensions with own spawn + dimension aware list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ compileJava {
 }
 
 minecraft {
-    version = "1.12.2-14.23.0.2512"
+    version = "1.12.2-14.23.1.2555"
     runDir = "run"
     mappings = "snapshot_20171010"
 }

--- a/src/main/java/com/m4thg33k/tombmanygraves/client/gui/GuiDeathItems.java
+++ b/src/main/java/com/m4thg33k/tombmanygraves/client/gui/GuiDeathItems.java
@@ -8,6 +8,7 @@ import com.m4thg33k.tombmanygraves.inventoryManagement.InventoryHolder;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.DimensionType;
 
 public class GuiDeathItems extends ModBaseGui{
 
@@ -120,6 +121,8 @@ public class GuiDeathItems extends ModBaseGui{
         {
             header.add("Grave at: (x,y,z)=(" + pos.getX() + "," + pos.getY() + "," + pos.getZ() + ")");
         }
+        DimensionType type = DimensionType.getById(inventoryHolder.getDimension());
+        header.add("Dimension: " + type.getName() + "(" + inventoryHolder.getDimension() + ")");
         header.add("Timestamp: " + inventoryHolder.getTimestamp());
     }
 

--- a/src/main/java/com/m4thg33k/tombmanygraves/inventoryManagement/DeathInventoryHandler.java
+++ b/src/main/java/com/m4thg33k/tombmanygraves/inventoryManagement/DeathInventoryHandler.java
@@ -164,37 +164,7 @@ public class DeathInventoryHandler {
                 ItemStack theList = new ItemStack(ModItems.itemDeathList, 1);
                 theList.setTagCompound(allNBT);
 
-                BlockPos pos = playerOld.getPosition();
-                EntityPlayer thePlayer = playerOld;
-                if (didDie)
-                {
-                    thePlayer = playerNew;
-                    LogHelper.info("Player respawn dimension: " + playerOld.getSpawnDimension());
-                    LogHelper.info("Player respawn dimension: " + playerOld.world.provider.getRespawnDimension((EntityPlayerMP)playerOld));
-                    LogHelper.info(playerOld.hasSpawnDimension());
-//                    BlockPos bedPos = player.getBedLocation(player.getSpawnDimension());
-                    BlockPos bedPos = playerOld.getBedLocation(playerOld.world.provider.getDimension());
-                    if (bedPos != null)
-                    {
-                        LogHelper.info("A " + bedPos.toString());
-                        pos = bedPos;
-                    }
-                    else
-                    {
-                        bedPos = playerOld.getBedLocation(playerOld.getSpawnDimension());
-                        if (bedPos != null){
-                            LogHelper.info("B " + bedPos.toString());
-                            pos = bedPos;
-                        } else {
-                            pos = playerOld.world.getSpawnPoint();
-                        }
-                    }
-                }
-                EntityItem entityItem = new EntityItem(thePlayer.world, pos.getX(), pos.getY(), pos.getZ(), theList);
-                thePlayer.world.spawnEntity(entityItem);
-//                EntityItem entityItem = new EntityItem(playerOld.world, pos.getX(), pos.getY(), pos.getZ(), theList);
-//                playerOld.world.spawnEntity(entityItem);
-                LogHelper.info("Spawning Death List in world: " + thePlayer.world.provider.getDimension() + " at location: " + pos.toString());
+                playerNew.addItemStackToInventory(theList);
             }
             else
             {

--- a/src/main/java/com/m4thg33k/tombmanygraves/inventoryManagement/InventoryHolder.java
+++ b/src/main/java/com/m4thg33k/tombmanygraves/inventoryManagement/InventoryHolder.java
@@ -35,6 +35,7 @@ public class InventoryHolder {
     public static final String EMPTY = "IsEmpty";
     public static final String TIMESTAMP = "Timestamp";
     public static final String PLAYER_NAME = "PlayerName";
+    public static final String PLAYER_DIMENSION = "PlayerDimension";
     public static final String BAUBLE_INVENTORY = "BaubleInventory";
     public static final String X = "Xcoord";
     public static final String Y = "Ycoord";
@@ -52,6 +53,7 @@ public class InventoryHolder {
     private int ycoord = -1;
     private int zcoord = -1;
     private String playerName = "unknown";
+    private int dimension;
 
     public InventoryHolder()
     {
@@ -143,6 +145,7 @@ public class InventoryHolder {
 
         playerName = player.getName();
         compound.setString(PLAYER_NAME, playerName);
+        compound.setInteger(PLAYER_DIMENSION, player.dimension);
 
         setTimestamp(new SimpleDateFormat("MM_dd_YYYY_HH_mm_ss").format(new Date()));
     }
@@ -184,6 +187,11 @@ public class InventoryHolder {
     public String getTimestamp()
     {
         return timestamp;
+    }
+
+    public int getDimension()
+    {
+        return dimension;
     }
 
     private NBTTagList getTagFromInventory(IInventory inventory)
@@ -239,6 +247,7 @@ public class InventoryHolder {
 
             this.timestamp = compound.getString(TIMESTAMP);
             this.playerName = compound.getString(PLAYER_NAME);
+            this.dimension = compound.getInteger(PLAYER_DIMENSION);
         }
         else
         {
@@ -251,6 +260,7 @@ public class InventoryHolder {
 
             this.timestamp = "";
             this.playerName = "unknown";
+            this.dimension = 0;
         }
     }
 

--- a/src/main/java/com/m4thg33k/tombmanygraves/items/ItemDeathList.java
+++ b/src/main/java/com/m4thg33k/tombmanygraves/items/ItemDeathList.java
@@ -109,6 +109,23 @@ public class ItemDeathList extends Item {
         }
     }
 
+    private int getDimension(ItemStack stack) {
+        if (stack.isEmpty() || !stack.hasTagCompound())
+        {
+            return 0;
+        }
+        else {
+            NBTTagCompound compound = stack.getTagCompound();
+
+            if (compound.hasKey(InventoryHolder.TAG_NAME)) {
+                compound = compound.getCompoundTag(InventoryHolder.TAG_NAME);
+                return compound.getInteger(InventoryHolder.PLAYER_DIMENSION);
+            }
+
+            return 0;
+        }
+    }
+
     private Vector3f getDirectionalVector(ItemStack stack, Vector3f start)
     {
         Vector3f end = getEndVector(stack);
@@ -127,6 +144,9 @@ public class ItemDeathList extends Item {
         {
             return;
         }
+
+        if (worldIn.provider.getDimension() != getDimension(stack))
+            return;
 
         if (ModConfigs.REQUIRE_SNEAK_FOR_PATH && !entityIn.isSneaking())
         {


### PR DESCRIPTION
Fixed the list ending up at the wrong spawn location if the player have a bed in the players spawn dimension and the current dimension respawns the player without setting the spawn world on the player and having no be in the current dimension.
Now the player is given the list instead of spawning in the world, the player shouldn't have a full inventory when respawning.

Also made the list more dimensional aware:
- It doesn't show particles when the player is in another dimension as the position isn't correct
- It now shows what dimension the death happened in when open the gui for the list