### PR TITLE
Added option to save previous death lists in new grave

### DIFF
--- a/src/main/java/com/m4thg33k/tombmanygraves/inventoryManagement/InventoryHolder.java
+++ b/src/main/java/com/m4thg33k/tombmanygraves/inventoryManagement/InventoryHolder.java
@@ -17,6 +17,7 @@ import com.m4thg33k.tombmanygraves.inventoryManagement.specialCases.InventoryPet
 import com.m4thg33k.tombmanygraves.inventoryManagement.specialCases.WearableBackpacksHandler;
 import com.m4thg33k.tombmanygraves.items.ItemDeathList;
 
+import com.m4thg33k.tombmanygraves.lib.ModConfigs;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.player.EntityPlayer;
@@ -206,7 +207,7 @@ public class InventoryHolder {
     public static boolean isItemValidForGrave(ItemStack stack)
     {
         if (stack.isEmpty()
-                || stack.getItem() instanceof ItemDeathList
+                || (!ModConfigs.ALLOW_DEATH_LIST && stack.getItem() instanceof ItemDeathList)
                 || stack.getItem() == Item.getItemFromBlock(ModBlocks.blockGrave))
         {
             return false;

--- a/src/main/java/com/m4thg33k/tombmanygraves/lib/ModConfigs.java
+++ b/src/main/java/com/m4thg33k/tombmanygraves/lib/ModConfigs.java
@@ -24,6 +24,7 @@ public class ModConfigs {
 
     // Common configs
     public static boolean ENABLE_GRAVES;
+    public static boolean ALLOW_DEATH_LIST;
     public static boolean DROP_ITEMS_ON_GROUND;
     public static boolean GIVE_ITEMS_IN_GRAVE_PRIORITY;
     public static boolean DEFAULT_TO_LOCKED;
@@ -145,7 +146,10 @@ public class ModConfigs {
                 "spawned upon players deaths. This does not get rid of any graves currently in-world." +
                 " (Defaults to true...obviously.)").getBoolean();
 
-        DROP_ITEMS_ON_GROUND = config.get("graveConfigs", "dropItemsOnGround", false, "If set to true, instead of" +
+        ALLOW_DEATH_LIST = config.get("graveconfigs", "allowDeathListInGrave", true, "If true death lists from " +
+                "previous deaths are allowed in a new grave. (Defaults to true.)").getBoolean();
+
+        DROP_ITEMS_ON_GROUND = config.get("graveConfigs", "dropItemsOnGround", false, "If set to true, instead of " +
                 "attempting to place all items back in the player's original slots, the items will instead be placed " +
                 "on the ground like every other grave mod. (Defaults to false.)").getBoolean();
 


### PR DESCRIPTION
When dying over and over again when trying to recover a grave you lose the previous death note, this makes it so you can go on without needing to use commands