### PR TITLE
Fixed the 'setTimestamp' call to use an ISO 8601 compatible date format

### DIFF
--- a/src/main/java/com/m4thg33k/tombmanygraves/invman/InventoryHolder.java
+++ b/src/main/java/com/m4thg33k/tombmanygraves/invman/InventoryHolder.java
@@ -62,7 +62,7 @@ public class InventoryHolder {
         playerName = player.getName();
         compound.setString(PLAYER_NAME, playerName);
 
-        setTimestamp(new SimpleDateFormat("MM_dd_YYYY_HH_mm_ss").format(new Date()));
+        setTimestamp(new SimpleDateFormat("YYYY-MM-dd'T'HH:mm:ss'Z'").format(new Date()));
     }
     
     public List<ItemStack> getAllItems(){

--- a/src/main/java/com/m4thg33k/tombmanygraves/invman/InventoryHolder.java
+++ b/src/main/java/com/m4thg33k/tombmanygraves/invman/InventoryHolder.java
@@ -62,7 +62,7 @@ public class InventoryHolder {
         playerName = player.getName();
         compound.setString(PLAYER_NAME, playerName);
 
-        setTimestamp(new SimpleDateFormat("YYYY-MM-dd'T'HH:mm:ss'Z'").format(new Date()));
+        setTimestamp(new SimpleDateFormat("YYYY-MM-dd'T'HH:mm:ss").format(new Date()));
     }
     
     public List<ItemStack> getAllItems(){


### PR DESCRIPTION
When typing the command "/tmg_getdeathlist minnie1089" then pressing tab, the list of timestamps was very disorganised because of the date format used on the timestamps. This makes it difficult to find a specific one you are looking for.

This PR fixes that issue by making the timestamps use the ISO 8601 compatible "YYYY-MM-DDThh-mm-ssZ" format instead of "MM_DD_YYYY_hh_mm_ss".